### PR TITLE
fix: remove unnecessary line break in MainBlock component

### DIFF
--- a/src/components/Homepage/MainBlock/index.js
+++ b/src/components/Homepage/MainBlock/index.js
@@ -17,7 +17,6 @@ const MainBlock = ({
     <section className={styles['main-block-wrapper']}>
       <div className={`container ${styles['main-block']}`}>
         <Label value={redirectLabel} />
-
         <div className={styles['main-block__title-description']}>
           <PrismicRichText
             field={title}


### PR DESCRIPTION
- Removed an extra line break after the redirect label in the MainBlock component to enhance layout consistency and maintain clean code structure.